### PR TITLE
instead of WAITING lines, WAITING FOR STOP and dots are echoed

### DIFF
--- a/stopYACY.sh
+++ b/stopYACY.sh
@@ -22,13 +22,15 @@ fi
 
 (bin/apicall.sh "Steering.html?shutdown=true" > /dev/null && \
 echo "Please wait until the YaCy daemon process terminates [wget]" && \
-echo "You can monitor this with 'tail -f $YACY_DATA_PATH/LOG/yacy00.log' and 'fuser $YACY_DATA_PATH/LOG/yacy00.log'") || \
+echo "You can monitor this with 'tail -F $YACY_DATA_PATH/LOG/yacy00.log' or 'fuser $YACY_DATA_PATH/LOG/yacy00.log'") || \
 exit $?
 
 # wait until the yacy.running file disappears which means that YaCy has terminated
 # If you don't want to wait, just run this concurrently
+
+echo "WAITING FOR STOP"
 while [ -f "$YACY_DATA_PATH/yacy.running" ]
 do
-	echo "WAITING"
+	echo -n "."
 sleep 1
 done


### PR DESCRIPTION
instead of stream of WAITING lines on the terminal, only "WAITING FOR STOP" is echoed followed by dot instead of every WAITING line. 
as a result, more readable output is given to the operator, and the lenght of the 'dots line' gives the notion of how long the operation is running. 

also, hint for the 'tail' command was modified to use -F instead of -f. 
as yacy rotates it's logs, using tail -f, tail loses connection to current log in a short time. 
-F parameter follows the file rotation, so it can be used for a long time.
see 'man tail'
