### PR TITLE
modified crawler list - URL is external link to actual URL

### DIFF
--- a/htroot/js/Crawler.js
+++ b/htroot/js/Crawler.js
@@ -411,7 +411,7 @@ function showRSS(RSS) {
   if (doc != null) {
     if (crawllist_body.length > 100000) crawllist_body = "";
     for (var i=0; i<RSS.items.length; i++) {
-      crawllist_body = "<tr class='TableCellLight'><td><a href='ViewFile.html?action=info&urlHash=" + RSS.items[i].guid.value + "' class='small' target='_blank' title='" + RSS.items[i].link + "'>" + RSS.items[i].description + "</a></td><td><a href='ViewFile.html?action=info&urlHash=" + RSS.items[i].guid.value + "' class='small' target='_blank' title='" + RSS.items[i].link + "'>" + RSS.items[i].link + "</a></td></tr>" + crawllist_body;
+      crawllist_body = "<tr class='TableCellLight'><td><a href='ViewFile.html?action=info&urlHash=" + RSS.items[i].guid.value + "' class='small' target='_blank' title='" + RSS.items[i].link + "'>" + RSS.items[i].description + "</a></td><td><a href='" + RSS.items[i].link + "' class='small' target='_blank' title='" + RSS.items[i].link + "'>" + RSS.items[i].link + "</a></td></tr>" + crawllist_body;
     }
     doc.innerHTML = crawllist_head + crawllist_body + crawllist_tail;
   }


### PR DESCRIPTION
Modified crawllist so that the second field in table (URL) is a link to actual external URL, not the info page. 

Reason:
two links to same page was unnecessary and external link allows to view the crawled page immediately
