### PR TITLE
replaced all the links to legacy legacy wiki to legacy wiki

### DIFF
--- a/htroot/Bookmarks.html
+++ b/htroot/Bookmarks.html
@@ -179,7 +179,7 @@ document.write("\<a href=\"Bookmarks.rss?" + window.location.search.substring(1)
 <a href="#"><img src="env/grafics/api.png" width="60" height="40" alt="API" /></a>
 <span>The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.
 Click the API icon to load the RSS from the current selection.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 ::
 #(/display)#

--- a/htroot/IndexControlURLs_p.html
+++ b/htroot/IndexControlURLs_p.html
@@ -70,7 +70,7 @@ function updatepage(str) {
     The XHTML+RDFa data format is both a XML content format and a HTML display format and is considered as an important <a href="http://www.w3.org/2001/sw/" target="_blank">Semantic Web</a> content format.
     The same content can also be retrieved as pure <a href="api/yacydoc.xml?urlhash=#[urlhash]#">XML metadata</a> with DC tag name vocabulary.
     Click the API icon to see an example call to the search rss API.
-    To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+    To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
     </div>
     
     <h2>URL Database Administration</h2>

--- a/htroot/Network.html
+++ b/htroot/Network.html
@@ -34,7 +34,7 @@
 <div id="api"><a href="Network.xml" id="apilink"><img src="env/grafics/api.png" width="60" height="40" alt="API"/></a>
 <span>The information that is presented on this page can also be retrieved as XML.
 Click the API icon to see the XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 <script type="text/javascript">
 document.getElementById("apilink").setAttribute("href", "Network.xml?" + window.location.search.substring(1));

--- a/htroot/Table_API_p.html
+++ b/htroot/Table_API_p.html
@@ -51,7 +51,7 @@
 <a href="Tables_p.xml?table=api&count=100&search=" id="apilink"><img src="env/grafics/api.png" width="60" height="40" alt="API"/></a>
 <span>The information that is presented on this page can also be retrieved as XML.
 Click the API icon to see the XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 
     #(showtable)#::	

--- a/htroot/Table_RobotsTxt_p.html
+++ b/htroot/Table_RobotsTxt_p.html
@@ -19,7 +19,7 @@ document.write("\<a href=\"Tables_p.xml?table=robots&pk=\"\>")
 <img src="env/grafics/api.png" width="60" height="40" alt="API"/></a>
 <span>The information that is presented on this page can also be retrieved as XML.
 Click the API icon to see the XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 
     <h2>robots.txt table</h2>

--- a/htroot/Vocabulary_p.html
+++ b/htroot/Vocabulary_p.html
@@ -73,7 +73,7 @@ document.getElementById('apilink').setAttribute('href', 'Vocabulary_p.xml?' + wi
 </script>
 <span>The information that is presented on this page can also be retrieved as XML
 Click the API icon to see the RDF Ontology definition for this vocabulary.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 #(/edit)#
     

--- a/htroot/WatchWebStructure_p.html
+++ b/htroot/WatchWebStructure_p.html
@@ -57,7 +57,7 @@ The data that is visualized here can also be retrieved in a XML file, which list
 With a GET-property 'about' you get only reference relations about the host that you give in the argument field for 'about'.
 With a GET-property 'latest' you get a list of references that had been computed during the current run-time of YaCy, and with each next call only an update to the next list of references.
 Click the API icon to see the XML file.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 
 <h2>Web Structure</h2>

--- a/htroot/WikiHelp.html
+++ b/htroot/WikiHelp.html
@@ -11,7 +11,7 @@
    <caption>
      This table contains a short description of the tags that can be used in the Wiki and several other servlets
      of YaCy. For a more detailed description visit the
-     <a href="http://www.yacy-websuche.de/wiki/index.php/Hauptseite" target="_blank">YaCy Wiki</a>.
+     <a href="https://wiki.yacy.net/index.php/Hauptseite" target="_blank">YaCy Wiki</a>.
    </caption>
    <tr valign="top">
     <th>

--- a/htroot/api/yacydoc.html
+++ b/htroot/api/yacydoc.html
@@ -16,7 +16,7 @@ you can validate it with http://validator.w3.org/
 <a href="yacydoc.xml"><img src="../env/grafics/api.png" width="60" height="40" alt="API" /></a>
 <span>This search result can also be retrieved as XML.
 Click the API icon to see an example call to the search rss API.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>	
     #%env/templates/metas.template%#
     <title>#[dc_title]#</title>

--- a/htroot/yacyinteractive.html
+++ b/htroot/yacyinteractive.html
@@ -24,7 +24,7 @@ document.write("\<a id=\"rsslink\" href=\"/solr/select?hl=false&wt=opensearch&fa
 <span>This search result can also be retrieved as RSS/<a href="http://www.opensearch.org" target="_blank">opensearch</a> output.
 The query format is similar to <a href="http://www.loc.gov/standards/sru/" target="_blank">SRU</a>.
 Click the API icon to see an example call to the search rss API.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 
 <div>

--- a/htroot/yacysearch_location.html
+++ b/htroot/yacysearch_location.html
@@ -168,7 +168,7 @@ document.getElementById('apilink').setAttribute('href', 'yacysearch_location.rss
 </script>
 <span>The information that is presented on this page can also be retrieved as XML
 Click the API icon to see the XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.</span>
 </div>
 
 <div class="row">

--- a/locales/de.lng
+++ b/locales/de.lng
@@ -275,7 +275,7 @@ YaCy '#[clientname]#': Bookmarks==YaCy '#[clientname]#': Lesezeichen
 
 The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.==Die Liste der Lesezeichen kann auch als RSS Feed abgerufen werden. Dies ist auch beim Auswählen eines bestimmten Tags möglich.
 Click the API icon to load the RSS from the current selection.==Klicken Sie auf die API Sprechblase, um einen RSS Feed der aktuellen Auswahl zu laden.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API Seite im Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API Seite im Wiki</a>.
 <h3>Bookmarks==<h3>Lesezeichen
 Bookmarks (==Lesezeichen (
 #Login==Login
@@ -2242,7 +2242,7 @@ YaCy Search Network==YaCy Suche Netzwerk
 YaCy Network<==YaCy Netzwerk<
 The information that is presented on this page can also be retrieved as XML.==Die Informationen auf dieser Seite können auch im XML Format abgerufen werden.
 Click the API icon to see the XML.==Klicken Sie auf das API Symbol, um das XML anzeigen zu lassen.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API Seite im Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API Seite im Wiki</a>.
 Network Overview==Netzwerkübersicht
 Active&nbsp;Peers==Aktive Peers
 Passive&nbsp;Peers==Passive Peers
@@ -3499,7 +3499,7 @@ You can edit your profile <a href="ConfigProfile_p.html">here</a>==Sie können I
 <html lang="en">==<html lang="de">
 The information that is presented on this page can also be retrieved as XML==Die Informationen auf dieser Seite können auch im XML Format abgerufen werden
 Click the API icon to see the RDF Ontology definition for this vocabulary.==Klicken Sie auf das API Symbol, um die RDF Ontology Definition für diese Vokabelliste anzuzeigen.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API Seite im Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API Seite im Wiki</a>.
 Vocabulary Administration==Vokabel Administration
 Vocabularies can be used to produce a search navigation. A vocabulary must be created before content is indexed.==Vokabeln können genutzt werden, um eine Suchnavigation zu erzeugen. Eine Vokabelliste muss erzeugt werden bevor der Inhalt indexiert wird.
 The vocabulary is used to annotate the indexed content with a reference to the object that is denoted by the term of the vocabulary.==Die Vokabelliste wird benutzt, um den indexierten Inhalt mit einer Referenz auf das Objekt zu versehen dass in der Bedeutung der Vokabel hinterlegt ist.

--- a/locales/fr.lng
+++ b/locales/fr.lng
@@ -1373,7 +1373,7 @@ YaCy Search Network==R&eacute;seau de recherche YaCy
 >YaCy Network<==>R&eacute;seau YaCy<
 The information that is presented on this page can also be retrieved as XML.==Les informations pr&eacute;sent&eacute;es ici peuvent &ecirc;tre obtenues au format XML.
 Click the API icon to see the XML.==Cliquez sur l'ic&ocirc;ne API pour afficher le XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Vous trouverez <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">ici</a> la liste compl&egrave;te des APIs.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Vous trouverez <a href="https://wiki.yacy.net/index.php/Dev:API">ici</a> la liste compl&egrave;te des APIs.
 Network Overview==Aper&ccedil;u du r&eacute;seau
 Active&nbsp;Peers==Noeuds actifs
 Passive&nbsp;Peers==Noeuds passifs
@@ -2560,7 +2560,7 @@ If a line starts with a space, it will be displayed in a non-proportional font.=
 YaCy Interactive Search==YaCy Recherche interactive
 #This page uses the JSON search API to display search results as you type.==Diese Seite verwendet die JSON Such API, um die Suchergebnisse beim Tippen anzuzeigen.
 #Click the API icon to see an example call to the native API.==Klicken Sie auf die API Sprechblase, um einen Beispielaufruf der nativen API zu sehen.
-#To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API Seite im Wiki</a>.
+#To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Um eine Liste aller APIs zu sehen, besuchen Sie die <a href="https://wiki.yacy.net/index.php/Dev:API">API Seite im Wiki</a>.
 >total results==>Total des r&eacute;sultats
 &nbsp;topwords:==&nbsp;Top mots:
 >Name==>Nom

--- a/locales/hi.lng
+++ b/locales/hi.lng
@@ -226,7 +226,7 @@ here.==यहां.
 YaCy '#[clientname]#': Bookmarks==यासी '#[clientname]#': बुकमार्क्स
 The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.==यह बुकमार्क्स की सूचि आरएसएस फीड्स में  पुनः प्राप्त की जा सकती है . आप एक विशिष्ट टैग का चयन करते हैं तो यह भी किया जा सकता है..
 Click the API icon to load the RSS from the current selection.==मौजूदा चयन से आरएसएस लोड करने के लिए एपीआई आइकन पर क्लिक करें.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==एपीआई की लिस्ट देखने के लिए विजिट करे  <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">एपीआई विकी पेज </a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==एपीआई की लिस्ट देखने के लिए विजिट करे  <a href="https://wiki.yacy.net/index.php/Dev:API">एपीआई विकी पेज </a>.
 <h3>Bookmarks==<h3>बुकमार्क्स 
 Bookmarks (==बुकमार्क्स  (
 #Login==लॉग इन 

--- a/locales/ja.lng
+++ b/locales/ja.lng
@@ -294,7 +294,7 @@ YaCy '#[clientname]#': Bookmarks==YaCy '#[clientname]#': ブックマーク
 
 The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.==ブックマークのリストはRSS フィードとして取得する事もできます. あなたが特定のタグを選択する時にこれを行う事もできます.
 Click the API icon to load the RSS from the current selection.==現在選択されているものからRSSを読み込むにはAPIのアイコンをクリックして下さい.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==全てのAPIの一覧を見る為には、<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki ページ</a>を訪問して下さい.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==全てのAPIの一覧を見る為には、<a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki ページ</a>を訪問して下さい.
 <h3>Bookmarks==<h3>ブックマーク
 Bookmarks (==ブックマーク (
 #Login==ログイン

--- a/locales/master.lng.xlf
+++ b/locales/master.lng.xlf
@@ -678,7 +678,7 @@
        <source>Click the API icon to load the RSS from the current selection.</source>
     </trans-unit>
     <trans-unit id="68813072" xml:space="preserve" approved="no" translate="yes">
-       <source>To see a list of all APIs, please visit the &lt;a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
+       <source>To see a list of all APIs, please visit the &lt;a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
     </trans-unit>
     <trans-unit id="cb18d8a6" xml:space="preserve" approved="no" translate="yes">
        <source>&lt;h3&gt;Bookmarks</source>
@@ -4369,7 +4369,7 @@
        <source>Click the API icon to see an example call to the search rss API.</source>
     </trans-unit>
     <trans-unit id="68813072" xml:space="preserve" approved="no" translate="yes">
-       <source>To see a list of all APIs, please visit the &lt;a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
+       <source>To see a list of all APIs, please visit the &lt;a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
     </trans-unit>
     <trans-unit id="4171bdd2" xml:space="preserve" approved="no" translate="yes">
        <source>URL Database Administration</source>
@@ -5830,7 +5830,7 @@
        <source>Click the API icon to see the XML.</source>
     </trans-unit>
     <trans-unit id="68813072" xml:space="preserve" approved="no" translate="yes">
-       <source>To see a list of all APIs, please visit the &lt;a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
+       <source>To see a list of all APIs, please visit the &lt;a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
     </trans-unit>
     <trans-unit id="cffbaf6b" xml:space="preserve" approved="no" translate="yes">
        <source>Network Overview</source>
@@ -9335,7 +9335,7 @@
        <source>Click the API icon to see the RDF Ontology definition for this vocabulary.</source>
     </trans-unit>
     <trans-unit id="68813072" xml:space="preserve" approved="no" translate="yes">
-       <source>To see a list of all APIs, please visit the &lt;a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
+       <source>To see a list of all APIs, please visit the &lt;a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank"&gt;API wiki page&lt;/a&gt;.</source>
     </trans-unit>
     <trans-unit id="1990fad8" xml:space="preserve" approved="no" translate="yes">
        <source>Vocabulary Administration</source>

--- a/locales/ru.lng
+++ b/locales/ru.lng
@@ -311,7 +311,7 @@ YaCy '#[clientname]#': Bookmarks==YaCy '#[clientname]#': Закладки
 
 The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.==Список закладок можно также получить как RSS-ленту. Это может быть сделано при выборе конкретного тега .
 Click the API icon to load the RSS from the current selection.==Нажмите на иконку API для загрузки RSS из текущего выделения.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">wiki-страницу API</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">wiki-страницу API</a>.
 <h3>Bookmarks==<h3>Закладки
 Bookmarks (==Закладки (
 #Login==Логин
@@ -1773,7 +1773,7 @@ document containg <a href="http://www.w3.org/RDF/" target="_blank">RDF</a> annot
 The XHTML+RDFa data format is both a XML content format and a HTML display format and is considered as an important <a href="http://www.w3.org/2001/sw/" target="_blank">Semantic Web</a> content format.==Формат данных XHTML+RDFa в виде XML-содержания и HTML-отображения, рассматривается в качестве важного формата <a href="http://www.w3.org/2001/sw/" target="_blank">семантической сети</a>.
 The same content can also be retrieved as pure <a href="api/yacydoc.xml?urlhash=#[urlhash]#">XML metadata</a> with DC tag name vocabulary.==Некоторое содержимое может быть также получено в виде <a href="api/yacydoc.xml?urlhash=">XML-метаданных</a> с словарём тэгов имён DC.
 Click the API icon to see an example call to the search rss API.==Нажмите на иконку для просмотра API примера поиска по rss-ленте.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">страницу API wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">страницу API wiki</a>.
 URL Database Administration==Управление базой данных ссылок
 #URL References Administration==Управление URL-ссылками
 The local index currently contains #[ucount]# URL references==Локальный индекс содержит на данный момент #[ucount]# ссылок
@@ -2356,7 +2356,7 @@ YaCy Search Network==Мониторинг сети YaCy
 YaCy Network<==Сеть YaCy<
 The information that is presented on this page can also be retrieved as XML.==Информация, указанная на этой странице, также может быть получена как XML.
 Click the API icon to see the XML.==Нажмите на иконку API, чтобы увидеть XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">страницу в Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">страницу в Wiki</a>.
 Network Overview==Обзор сети
 Active&nbsp;Principal&nbsp;and&nbsp;Senior&nbsp;Peers==Активные главные и старшие узлы
 Passive&nbsp;Senior&nbsp;Peers==Пассивные старшие узлы
@@ -3648,7 +3648,7 @@ You can edit your profile <a href="ConfigProfile_p.html">here</a>==Вы може
 YaCy '#[clientname]#': Federated Index==YaCy '#[clientname]#': Управление словарём
 The information that is presented on this page can also be retrieved as XML==Информация представленная на этой странице, также может быть получена в виде XML.
 Click the API icon to see the RDF Ontology definition for this vocabulary.==Нажмите на иконку API для просмотра определения онтологии RDF для этого словаря.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">страницу API Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==Для просмотра списка всех API, пожалуйста, посетите <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">страницу API Wiki</a>.
 Vocabulary Administration==Управление словарём
 Vocabularies can be used to produce a search navigation. A vocabulary must be created before content is indexed.==Словари могут использоваться при выполнении навигации по поиску. Словарь должен быть создан до индексации содержимого сайта.
 The vocabulary is used to annotate the indexed content with a reference to the object that is denoted by the term of the vocabulary.==Словарь используется для комментирования проиндексированного содержимого с ссылкой на объект, которому присвоено значение из словаря.

--- a/locales/uk.lng
+++ b/locales/uk.lng
@@ -232,7 +232,7 @@ YaCy '#[clientname]#': Bookmarks==YaCy '#[clientname]#': Закладки
 The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.==Список закладок може також бути отриманий як RSS. Це можливо також при виборі конкретних ключових слів.
 
 Click the API icon to load the RSS from the current selection.==Натисніть на піктограму API для завантаження RSS з поточного вибору.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Для перегляду списку всіх API, будь-ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">сторінку API у Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Для перегляду списку всіх API, будь-ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">сторінку API у Wiki</a>.
 
 <h3>Bookmarks==<h3>Закладки
 Bookmarks (==Закладки (
@@ -1995,7 +1995,7 @@ YaCy Search Network==Пошукова мережа YaCy
 YaCy Network<==Мережа YaCy<
 The information that is presented on this page can also be retrieved as XML.==Інформацію на цій сторінці також можна отримати в форматі XML.
 Click the API icon to see the XML.==Натисніть значок API для відображення XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Для перегляду списку всіх API, будь-ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">сторінку API у Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Для перегляду списку всіх API, будь-ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">сторінку API у Wiki</a>.
 Network Overview==Огляд мережі
 Active&nbsp;Peers==Активні&nbsp;вузли
 Passive&nbsp;Peers==Пасивні&nbsp;вузли
@@ -3011,7 +3011,7 @@ Call Count<==Виклики<
 Scheduled actions are executed after the next execution date has arrived within a time frame of #[tfminutes]# minutes.==Заплановані дії виконуються в межах тимчасове вікна в #[tfminutes]# хвилин, коли наступна дата виконання буде досягнута.
 The information that is presented on this page can also be retrieved as XML.==Інформацію на цій сторінці також можна отримати в форматі XML.
 Click the API icon to see the XML.==Натисніть значок API для відображення XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Для перегляду списку всіх API, будь-ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">сторінку API у Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Для перегляду списку всіх API, будь-ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">сторінку API у Wiki</a>.
 #-----------------------------
 
 #File: Table_RobotsTxt_p.html
@@ -3019,7 +3019,7 @@ To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de
 Table Viewer==Перегляд таблиці
 The information that is presented on this page can also be retrieved as XML.==Інформацію на цій сторінці також можна отримати в форматі XML.
 Click the API icon to see the XML.==Натисніть значок API для відображення XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Щоб побачити список усіх API, будь ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">вікі-сторінку API</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Щоб побачити список усіх API, будь ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">вікі-сторінку API</a>.
 >robots.txt table<==>Таблиця robots.txt<
 #-----------------------------
 
@@ -3242,7 +3242,7 @@ The data that is visualized here can also be retrieved in a XML file, which list
 With a GET-property 'about' you get only reference relations about the host that you give in the argument field for 'about'.==З властивістю GET "about" можна витягувати тільки зв’язки відносно сервера, поданого в полі аргументу "about".
 With a GET-property 'latest' you get a list of references that had been computed during the current run-time of YaCy, and with each next call only an update to the next list of references.==З властивістю GET "latest" можна отримати список посилань, що був розрахований протягом поточної роботи YaCy. І з кожним викликом, тільки оновлення до наступного списку посилань.
 Click the API icon to see the XML file.==Натисніть значок API для перегляду XML-файлу.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Щоб переглянути список усіх API, будь ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">вікі-сторінку API</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Щоб переглянути список усіх API, будь ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">вікі-сторінку API</a>.
 
 Web Structure==Структура мережі
 host<==хост<
@@ -3346,7 +3346,7 @@ YaCy Interactive Search==Живий пошук YaCy
 This search result can also be retrieved as RSS/<a href="http://www.opensearch.org">opensearch</a> output.==Результати пошуку можна отримати також у вигляді RSS/<a href="http://www.opensearch.org">opensearch</a>.
 The query format is similar to <a href="http://www.loc.gov/standards/sru/">SRU</a>.==Формат запитів подібний до <a href="http://www.loc.gov/standards/sru/">SRU</a>.
 Click the API icon to see an example call to the search rss API.==Щиглик API, щоб побачити зразок виклику пошукового API RSS.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Щоб побачити список усіх API, будь ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">вікі-сторінку API</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Щоб побачити список усіх API, будь ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">вікі-сторінку API</a>.
 loading from local index...==завантаження з місцевого індексу...
 e="Search"==e="Пошук"
 #-----------------------------
@@ -3357,7 +3357,7 @@ Search Page==Сторінка пошуку
 This search result can also be retrieved as RSS/<a href="http://www.opensearch.org">opensearch</a> output.==Ці результати пошуку також доступні у вигляді RSS/<a href="http://www.opensearch.org">opensearch</a>.
 The query format is similar to <a href="http://www.loc.gov/standards/sru/">SRU</a>.==Формат запиту схожий на <a href="http://www.loc.gov/standards/sru/">SRU</a>.
 Click the API icon to see an example call to the search rss API.==Клацніть по значку API, щоб побачити зразок виклику пошукового API RSS.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==Щоб побачити список усіх API, будь ласка, відвідайте <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">вікі-сторінку API</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==Щоб побачити список усіх API, будь ласка, відвідайте <a href="https://wiki.yacy.net/index.php/Dev:API">вікі-сторінку API</a>.
 Did you mean:==Можливо, ви мали на увазі:
 "Search"=="Пошук"
 'Search'=='Пошук'

--- a/locales/zh.lng
+++ b/locales/zh.lng
@@ -263,12 +263,12 @@ here.==在这里.
 start autosearch of new bookmarks==开始自动搜索新书签
 This starts a search of new or modified bookmarks since startup==开始搜索自从启动以来新的或修改的书签
 Every peer online will be ask for results.==每个在线的节点都会被索要结果。
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==要查看所有API的列表，请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>。
-To see a list of all APIs==要查看所有API的列表，请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>。
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==要查看所有API的列表，请访问<a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>。
+To see a list of all APIs==要查看所有API的列表，请访问<a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>。
 YaCy '#[clientname]#': Bookmarks==YaCy '#[clientname]#': 书签
 The bookmarks list can also be retrieved as RSS feed. This can also be done when you select a specific tag.==书签列表也能用作RSS订阅.当你选择某个标签时你也可执行这个操作.
 Click the API icon to load the RSS from the current selection.==点击API图标以从当前选择书签中载入RSS.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==获取所有API, 请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==获取所有API, 请访问<a href="https://wiki.yacy.net/index.php/Dev:API">API Wiki</a>.
 <h3>Bookmarks==<h3>书签
 Bookmarks (==书签(
 Login==登录
@@ -3567,7 +3567,7 @@ To see a list of all APIs, please visit the==To see a list of all APIs, please v
 Table Viewer==表格查看器
 The information that is presented on this page can also be retrieved as XML.==此页信息也可表示为XML.
 Click the API icon to see the XML.==点击API图标查看XML.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==查看所有API, 请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==查看所有API, 请访问<a href="https://wiki.yacy.net/index.php/Dev:API">API Wiki</a>.
 API wiki page==API百科页面
 To see a list of all APIs, please visit the==要查看所有API的列表，请访问
 >robots.txt table<==>robots.txt列表<
@@ -3845,7 +3845,7 @@ The data that is visualized here can also be retrieved in a XML file, which list
 With a GET-property 'about' you get only reference relations about the host that you give in the argument field for 'about'.==使用GET属性'about'仅能获得带有'about'参数的域关联关系.
 With a GET-property 'latest' you get a list of references that had been computed during the current run-time of YaCy, and with each next call only an update to the next list of references.==使用GET属性'latest'能获得当前的关联关系列表, 并且每一次调用都只能更新下一级关联关系列表.
 Click the API icon to see the XML file.==点击API图标查看XML文件.
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API wiki page</a>.==查看所有API, 请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API">API Wiki</a>.
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API">API wiki page</a>.==查看所有API, 请访问<a href="https://wiki.yacy.net/index.php/Dev:API">API Wiki</a>.
 Web Structure==网页结构
 host<==服务器<
 depth<==深度<
@@ -3951,7 +3951,7 @@ YaCy Interactive Search==YaCy交互搜索
 This search result can also be retrieved as RSS/<a href="http://www.opensearch.org" target="_blank">opensearch</a> output.==此搜索结果能以RSS/<a href="http://www.opensearch.org" target="_blank">opensearch</a>被形式检索。
 The query format is similar to <a href="http://www.loc.gov/standards/sru/" target="_blank">SRU</a>.==请求的格式与<a href="http://www.loc.gov/standards/sru/" target="_blank">SRU</a>相似。
 Click the API icon to see an example call to the search rss API.==点击API图标查看调用rss API的示例。
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==查看所有API, 请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API百科页面</a>。
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==查看所有API, 请访问<a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API百科页面</a>。
 >loading from local index...<==>从本地索引加载...<
 "Search"=="搜索"
 "Search..."=="搜索中..."
@@ -3962,7 +3962,7 @@ To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de
 YaCy '#[clientname]#': Location Search==YaCy '#[clientname]#':位置搜索
 The information that is presented on this page can also be retrieved as XML==此页面上显示的信息也可以作为XML检索
 Click the API icon to see the XML.==单击 API 图标以查看 XML。
-To see a list of all APIs, please visit the <a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki page</a>.==要查看所有 API 的列表，请访问<a href="http://www.yacy-websuche.de/wiki/index.php/Dev:API" target="_blank">API wiki</a>页面。
+To see a list of all APIs, please visit the <a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki page</a>.==要查看所有 API 的列表，请访问<a href="https://wiki.yacy.net/index.php/Dev:API" target="_blank">API wiki</a>页面。
 >search<==>搜索<
 #-----------------------------
 

--- a/source/net/yacy/data/list/XMLBlacklistImporter.java
+++ b/source/net/yacy/data/list/XMLBlacklistImporter.java
@@ -36,7 +36,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * This class provides methods to import blacklists from an XML file (see
- * http://www.yacy-websuche.de/wiki/index.php/Dev:APIblacklists
+ * https://wiki.yacy.net/index.php/Dev:APIblacklists
  * for examples) and to return this data as a {@link ListAccumulator} object.
  */
 public class XMLBlacklistImporter extends DefaultHandler {


### PR DESCRIPTION
since a lot of links to defunct yacy-websuche.de/wiki/ persisted in yacy, i replaced them (find-and-replace using sed) with wiki.yacy.net. 
i know, that wiki is going to be abandoned, but probably better to have legacy links than defunct ones
