### PR TITLE
update woodstox-core (including the renaming) to 6.2.8 to use the cor…

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -69,9 +69,7 @@
       <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.6.2" conf="compile->master" />
       <dependency org="org.bitlet" name="weupnp" rev="0.1.4"  />
       <dependency org="org.bouncycastle" name="bcmail-jdk18on" rev="1.79" />
-      <dependency org="org.codehaus.woodstox" name="woodstox-core-asl" rev="4.4.1">
-        <exclude module="stax-api" />
-      </dependency>
+      <dependency org="com.fasterxml.woodstox" name="woodstox-core" rev="6.2.8" />
       <dependency org="org.eclipse.jetty" name="jetty-client" rev="9.4.56.v20240826" />
       <dependency org="org.eclipse.jetty" name="jetty-deploy" rev="9.4.56.v20240826" conf="compile->master" />
       <dependency org="org.eclipse.jetty" name="jetty-jmx" rev="9.4.56.v20240826" conf="compile->master"/>


### PR DESCRIPTION
…rect version for Solr 9.0